### PR TITLE
Fix typo in GitHub Actions workflow by changing "Package Name" to "Pa…

### DIFF
--- a/.github/workflows/update-version-from-pa.yml
+++ b/.github/workflows/update-version-from-pa.yml
@@ -69,7 +69,7 @@ jobs:
         body: |
           ## 🚀 Version Update from Power Automate
           
-          **Package Name:** `${{ inputs.packageName }}`
+          **Package Names:** `${{ inputs.packageName }}`
           **Version Type:** `${{ inputs.versionType }}`
           **SDK Version:** `${{ inputs.versionSDK }}`
           


### PR DESCRIPTION
…ckage Names" for clarity in version update notifications.